### PR TITLE
fix: bug fixes - puppeteer leak, retry limit, badminton maintenance

### DIFF
--- a/app.js
+++ b/app.js
@@ -187,19 +187,19 @@ bot.command('currentFlashdeal', ctx => {
 
 // Start of Badminton
 
+const BADMINTON_MAINTENANCE = "Fitur badminton lagi maintenance nih 🔧 Tunggu update selanjutnya ya!"
+
 bot.command('hasilbadmintonindonesia', ctx => {
-    hasilIndonesia(ctx)
+    ctx.reply(BADMINTON_MAINTENANCE)
 })
 
 bot.command('hasilbadminton', ctx => {
-    hasilSemua(ctx)
+    ctx.reply(BADMINTON_MAINTENANCE)
 })
 
 bot.command('subscribebadminton', ctx => {
-    subscribeBadminton(ctx)
+    ctx.reply(BADMINTON_MAINTENANCE)
 })
-
-setupBadmintonBot(bot)
 
 // End of Badminton
 

--- a/features/formula.js
+++ b/features/formula.js
@@ -174,9 +174,9 @@ function getCurrentF1Race() {
  */
 async function getF1RaceResult(year, meetingKey, country) {
     const url = `https://www.formula1.com/en/results/${year}/races/${meetingKey}/${country}/race-result`;
-
+    let browser;
     try {
-        const browser = await puppeteer.launch({
+        browser = await puppeteer.launch({
             dumpio: true,
             args: ['--no-sandbox', '--disable-setuid-sandbox']
         });
@@ -187,17 +187,17 @@ async function getF1RaceResult(year, meetingKey, country) {
             'accept-language': 'en-US,en;q=0.9',
             'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36'
         });
-        
+
         await page.goto(url, { waitUntil: 'networkidle2' });
         await page.waitForSelector('table tbody tr', { timeout: 5000 }).catch(() => {});
 
         const data = await page.content();
-        await browser.close();
-
         return parseF1Results(data);
     } catch (error) {
         console.error('Error fetching F1 results:', error);
         return [];
+    } finally {
+        if (browser) await browser.close();
     }
 }
 
@@ -237,7 +237,7 @@ function parseF1Results(htmlContent) {
  * Format to Telegram string
  */
 function formatF1TelegramMessage(results, country) {
-    const capitalizedCountry = country.charAt(0).toUpperCase() + country.slice(1).replace('-', ' ');
+    const capitalizedCountry = country.charAt(0).toUpperCase() + country.slice(1).replaceAll('-', ' ');
 
     let message = `🏎️💨 Ngeeeng!! Hasil Balapan F1 ${capitalizedCountry} GP udah keluar nih!! 🏁🏆\n`;
     message += `Yuk cek siapa aja yang naik podium! 👇\n\n`;
@@ -305,9 +305,9 @@ async function sendLastF1Result(ctx) {
 
 async function getF1QualifyingResult(year, meetingKey, country) {
     const url = `https://www.formula1.com/en/results/${year}/races/${meetingKey}/${country}/qualifying`;
-
+    let browser;
     try {
-        const browser = await puppeteer.launch({
+        browser = await puppeteer.launch({
             dumpio: true,
             args: ['--no-sandbox', '--disable-setuid-sandbox']
         });
@@ -318,17 +318,17 @@ async function getF1QualifyingResult(year, meetingKey, country) {
             'accept-language': 'en-US,en;q=0.9',
             'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36'
         });
-        
+
         await page.goto(url, { waitUntil: 'networkidle2' });
         await page.waitForSelector('table tbody tr', { timeout: 5000 }).catch(() => {});
 
         const data = await page.content();
-        await browser.close();
-
         return parseF1Qualifying(data);
     } catch (error) {
         console.error('Error fetching F1 qualifying:', error);
         return [];
+    } finally {
+        if (browser) await browser.close();
     }
 }
 
@@ -366,7 +366,7 @@ function parseF1Qualifying(htmlContent) {
 }
 
 function formatF1QualifyingMessage(results, country) {
-    const capitalizedCountry = country.charAt(0).toUpperCase() + country.slice(1).replace('-', ' ');
+    const capitalizedCountry = country.charAt(0).toUpperCase() + country.slice(1).replaceAll('-', ' ');
 
     let message = `⏱️💨 Ngeeeng!! Hasil Kualifikasi F1 ${capitalizedCountry} GP udah keluar nih!! 🏁🔥\n`;
     message += `Siapa yang dapet Pole Position? 👇\n\n`;

--- a/features/pemudatersesat.js
+++ b/features/pemudatersesat.js
@@ -170,7 +170,11 @@ function hindhu(ctx, id) {
 }
 
 // english -> change after comma to en.asad
-function moslem(ctx, id) {
+function moslem(ctx, id, retries = 3) {
+    if (retries <= 0) {
+        send(ctx, id, "Maaf ya kak, quote Al-Quran lagi error nih 😭 Coba lagi nanti ya!");
+        return;
+    }
     let rand = Math.floor(Math.random() * 6326) + 1;
     getData(`https://api.alquran.cloud/v1/ayah/${rand}/editions/quran-simple,id.indonesian`)
         .then(async data => {
@@ -184,12 +188,12 @@ function moslem(ctx, id) {
                 send(ctx, id, message);
             } catch (error) {
                 console.error("Error generating reflection:", error);
-                moslem(ctx, id)
+                moslem(ctx, id, retries - 1)
             }
         })
         .catch(error => {
             console.error("Error fetching Quran data:", error);
-            moslem(ctx, id)
+            moslem(ctx, id, retries - 1)
         });
 }
 

--- a/features/reminder.js
+++ b/features/reminder.js
@@ -61,7 +61,6 @@ function checkDifferences(ctx = null, demand = false) {
 
     var match
 
-    sleep(2000)
     var diff = new Date(listFixtures[0].matchdate_tdt).getTime() - new Date().getTime()
 
     if (diff <= 0) {


### PR DESCRIPTION
## Summary
- **Puppeteer browser leak** (`formula.js`): moved `browser.close()` into a `finally` block so Chromium processes are always cleaned up, even when scraping throws an error
- **Multi-hyphen country names** (`formula.js`): `replace('-', ' ')` → `replaceAll('-', ' ')` so names like `saudi-arabia` render correctly
- **`moslem()` infinite recursion** (`pemudatersesat.js`): added `retries = 3` cap — sends a friendly error message to the user after 3 failed attempts instead of recursing forever
- **Badminton maintenance** (`app.js`): all three badminton commands now reply with a maintenance message since the site was revamped and scraping is broken
- **No-op `sleep`** (`reminder.js`): removed unawaited `sleep(2000)` call that did nothing

## Test plan
- [ ] Trigger `/lastrace` or `/lastqualifying` during a race weekend and verify no zombie Chromium processes remain after the response
- [ ] Trigger `/pemudatersesat` → Islam multiple times with network down and confirm it stops with an error message after 3 tries
- [ ] Trigger `/hasilbadminton`, `/hasilbadmintonindonesia`, `/subscribebadminton` and confirm maintenance message is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)